### PR TITLE
add compose function to contramap a comparator

### DIFF
--- a/Compare.elm
+++ b/Compare.elm
@@ -1,4 +1,4 @@
-module Compare exposing (Comparator, by, concat, max, maximum, min, minimum, reverse)
+module Compare exposing (Comparator, by, compose, concat, max, maximum, min, minimum, reverse)
 
 {-| Tools for composing comparison functions.
 
@@ -18,7 +18,7 @@ You pass it two elements of a type and it returns an Order (defined in the Basic
 
 ## Composing compare functions
 
-@docs by, concat, reverse
+@docs by, concat, reverse, compose
 
 -}
 
@@ -159,3 +159,25 @@ max comparator x y =
 
         LT ->
             y
+
+
+{-| Apply a transformation to both incoming values before attempting to apply
+the previous comparator to the results
+
+    import Compare
+    import Score exposing (Score)
+
+    type alias Player =
+        { id : Id
+        , score : Score
+        }
+
+    highestScoringPlayer : List Player -> Maybe Player
+    highestScoringPlayer players =
+        players
+            |> Compare.maximum (Compare.compose .score Score.compare)
+
+-}
+compose : (a -> b) -> Comparator b -> Comparator a
+compose fn comparator left right =
+    comparator (fn left) (fn right)

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.0",
+    "version": "1.1.0",
     "summary": "Tools for composing comparison functions",
     "repository": "https://github.com/NoRedInk/elm-compare.git",
     "license": "BSD3",

--- a/tests/Spec.elm
+++ b/tests/Spec.elm
@@ -1,8 +1,8 @@
 module Spec exposing (spec)
 
+import Compare
 import Expect
 import Fuzz
-import Compare
 import Test exposing (..)
 
 
@@ -18,9 +18,9 @@ spec =
                     reverseOrdered =
                         List.sortWith (Compare.reverse compare) numbers
                 in
-                    reverseOrdered
-                        |> List.reverse
-                        |> Expect.equal ordered
+                reverseOrdered
+                    |> List.reverse
+                    |> Expect.equal ordered
         , test "#concat" <|
             \_ ->
                 let
@@ -41,17 +41,17 @@ spec =
                             _ ->
                                 EQ
                 in
-                    numbers
-                        |> List.sortWith (Compare.concat [ byEven, compare ])
-                        |> Expect.equal [ 1, 3, 5, 2, 4 ]
+                numbers
+                    |> List.sortWith (Compare.concat [ byEven, compare ])
+                    |> Expect.equal [ 1, 3, 5, 2, 4 ]
         , fuzz (Fuzz.list Fuzz.int) "#by" <|
             \numbers ->
                 let
                     compareFn x =
                         x % 2
                 in
-                    List.sortWith (Compare.by compareFn) numbers
-                        |> Expect.equal (List.sortBy compareFn numbers)
+                List.sortWith (Compare.by compareFn) numbers
+                    |> Expect.equal (List.sortBy compareFn numbers)
         , fuzz (Fuzz.list Fuzz.int) "#minimum" <|
             \numbers ->
                 Compare.minimum compare numbers
@@ -68,4 +68,9 @@ spec =
             \x y ->
                 Compare.max compare x y
                     |> Expect.equal (max x y)
+        , fuzz2 Fuzz.int Fuzz.int "#compose" <|
+            \x y ->
+                [ { value = x }, { value = y } ]
+                    |> Compare.maximum (Compare.compose .value Basics.compare)
+                    |> Expect.equal (Just { value = max x y })
         ]


### PR DESCRIPTION
This function covers situations where you have an opaque type that exposes its own `Comparator`, but you want to run comparisons on another type that maps to your opaque type. For functions that take one argument, this would be as simple as using `(>>)`, but since comparators require two arguments we need this special function.