### PR TITLE
Simplify `reverse`

### DIFF
--- a/Compare.elm
+++ b/Compare.elm
@@ -78,15 +78,7 @@ concat comparators a b =
 -}
 reverse : Comparator a -> Comparator a
 reverse comparator a b =
-    case comparator a b of
-        EQ ->
-            EQ
-
-        GT ->
-            LT
-
-        LT ->
-            GT
+    comparator b a
 
 
 {-| Like `List.minimum` but using a custom comparator.


### PR DESCRIPTION
Intuitively, the reverse of `compare a b` is `compare b a`. Coincidentally, that works out in code, too.